### PR TITLE
Fixing incorrect description formatting

### DIFF
--- a/contribution/development.md
+++ b/contribution/development.md
@@ -5,7 +5,7 @@ description: setup for developing Tuist
 # Setup
 
 Tuist is a Swift package which requires [Swift Package Manager](https://swift.org/package-manager/) (Swift PM) to build and develop it. If you already have [Xcode](https://developer.apple.com/xcode/) installed, then you are set! See the [Swift PM installation section](https://github.com/apple/swift-package-manager#installation) for details on alternate methods of setting it up.
-Getting
+
 # Building 
 
 To build Tuist, you can run the `build` command:

--- a/contribution/development.md
+++ b/contribution/development.md
@@ -1,14 +1,11 @@
-# docs
-
 ---
-description: >-
-  Getting setup for developing Tuist
+description: setup for developing Tuist
 ---
 
 # Setup
 
 Tuist is a Swift package which requires [Swift Package Manager](https://swift.org/package-manager/) (Swift PM) to build and develop it. If you already have [Xcode](https://developer.apple.com/xcode/) installed, then you are set! See the [Swift PM installation section](https://github.com/apple/swift-package-manager#installation) for details on alternate methods of setting it up.
-
+Getting
 # Building 
 
 To build Tuist, you can run the `build` command:

--- a/contribution/development.md
+++ b/contribution/development.md
@@ -1,5 +1,5 @@
 ---
-description: setup for developing Tuist
+description: Getting set up for developing Tuist
 ---
 
 # Setup


### PR DESCRIPTION
I accidentally introduced an incorrect description format for the development page in a previous commit

<img width="823" alt="screen shot 2019-02-08 at 6 33 16 pm" src="https://user-images.githubusercontent.com/11914919/52498201-06df4c00-2bd0-11e9-8e38-9430018c5d01.png"> 🤦‍♂️

Is there a way to preview the generated documentation?
